### PR TITLE
Support Read and Write connections.

### DIFF
--- a/src/Commands/DbAnonymizeCommand.php
+++ b/src/Commands/DbAnonymizeCommand.php
@@ -111,8 +111,10 @@ class DbAnonymizeCommand extends Command
 
         $connection = $this->laravel['config']['database.connections.'.$database];
 
+        $host = $connection['host'] ?? $connection['write']['host'][0] ?? '127.0.0.1';
+
         return [
-            'dsn' => "{$connection['driver']}:dbname={$connection['database']};host={$connection['host']};port={$connection['port']};charset={$connection['charset']}",
+            'dsn' => "{$connection['driver']}:dbname={$connection['database']};host={$host};port={$connection['port']};charset={$connection['charset']}",
             'username' => $connection['username'],
             'password' => $connection['password'],
         ];


### PR DESCRIPTION
This change would support the documented Laravel feature for implementing separate read & write connections.

See Laravel Documentation here: https://laravel.com/docs/7.x/database#read-and-write-connections

When setting up separate read and write connections, rather than a single `'host'` index on the `'mysql'` driver config, you would add a separate `'read'` and `'write'` index, each of which would contain a `'host'`, which contains an array of defined hosts.

This change would first check for `$connection['host']`.

If not found, it would check for `$connection['write']['host'][0]`.

Finally, if it cannot find any of these, it would use the default value of `'127.0.0.1'`.